### PR TITLE
Fix format and removal of leading zeros from SKI and AKI

### DIFF
--- a/certinfo/certinfo.go
+++ b/certinfo/certinfo.go
@@ -72,11 +72,8 @@ func ParseName(name pkix.Name) Name {
 func formatKeyID(id []byte) string {
 	var s string
 
-	for i, c := range id {
-		if i > 0 {
-			s += ":"
-		}
-		s += fmt.Sprintf("%X", c)
+	for _,c := range id {
+		s += fmt.Sprintf("%02x", c)
 	}
 
 	return s


### PR DESCRIPTION
CertInfo was returning the SKI and AKI fields in a different format to that which is used elsewhere. Additionally leading zeros on binary values where being removed, e.g. 03 was changed to 3.
